### PR TITLE
oracledb compress history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # 4.0.16
 
 * **OracledbDataStorage**
-    * add the option to compress the history
+    * add an option to compress the history, the compression/decompression is also applied to existing records
 * **SimpleObjectMapper#writeValueAsString**
-    * choose PRETTY/COMPACT/DEFAULT output style
+    * introduce PRETTY/COMPACT/DEFAULT output style
 * **Save history**
-    * always save history with COMPACT output style
+    * always save history using the COMPACT output style
 
 # 4.0.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * **OracledbDataStorage**
     * add the option to compress the history
+* **SimpleObjectMapper#writeValueAsString**
+    * choose PRETTY/COMPACT/DEFAULT output style
+* **Save history**
+    * always save history with COMPACT output style
 
 # 4.0.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.16
+
+* **OracledbDataStorage**
+    * add the option to compress the history
+
 # 4.0.15
 
 * **JettyServerBuilder**

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
     }
 
     group = 'io.github.factoryfx'
-    version = '4.0.15'
+    version = '4.0.16'
 
     publishing {
 

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/OutputStyle.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/OutputStyle.java
@@ -1,0 +1,23 @@
+package io.github.factoryfx.factory.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.util.function.Function;
+
+public enum OutputStyle {
+    PRETTY(ObjectMapper::writerWithDefaultPrettyPrinter),
+    COMPACT(objectMapper -> objectMapper.writer().without(SerializationFeature.INDENT_OUTPUT)),
+    DEFAULT(ObjectMapper::writer);
+
+    private final Function<ObjectMapper, ObjectWriter> mapperFunction;
+
+    OutputStyle(Function<ObjectMapper, ObjectWriter> mapperFunction) {
+        this.mapperFunction = mapperFunction;
+    }
+
+    public ObjectWriter getWriter(ObjectMapper objectMapper) {
+        return mapperFunction.apply(objectMapper);
+    }
+}

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
@@ -166,7 +166,7 @@ public class SimpleObjectMapper {
     @SuppressWarnings("unchecked")
     private <T> T readInternal(ResultFunction<T> function) {
         try {
-            T value = function.read();
+            T value = function.apply();
             if (value instanceof FactoryBase<?, ?>) {
                 return (T) ((FactoryBase<?, ?>) value).internal().finalise();
             }
@@ -178,7 +178,7 @@ public class SimpleObjectMapper {
 
     private void writeInternal(VoidFunction function) {
         try {
-            function.write();
+            function.apply();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -186,17 +186,17 @@ public class SimpleObjectMapper {
 
     private <T> T writeInternal(ResultFunction<T> function) {
         try {
-            return function.read();
+            return function.apply();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     private interface VoidFunction {
-        void write() throws IOException;
+        void apply() throws IOException;
     }
 
     private interface ResultFunction<T> {
-        T read() throws IOException;
+        T apply() throws IOException;
     }
 }

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
@@ -1,14 +1,5 @@
 package io.github.factoryfx.factory.jackson;
 
-import java.io.DataOutput;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Writer;
-import java.nio.file.Path;
-import java.util.List;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
@@ -16,10 +7,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
-
 import io.github.factoryfx.factory.FactoryBase;
 
-/** the main purpose of SimpleObjectMapper is to get rid of the checked exceptions */
+import java.io.*;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * the main purpose of SimpleObjectMapper is to get rid of the checked exceptions
+ */
 public class SimpleObjectMapper {
     private final ObjectMapper objectMapper;
 
@@ -148,11 +144,11 @@ public class SimpleObjectMapper {
     }
 
     public String writeValueAsString(Object value) {
-        return writeInternal(() -> objectMapper.writeValueAsString(value));
+        return writeValueAsString(value, OutputStyle.DEFAULT);
     }
 
-    public String writeValueAsString(Object value, boolean pretty) {
-        return writeInternal(() -> pretty ? objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value) : objectMapper.writeValueAsString(value));
+    public String writeValueAsString(Object value, OutputStyle outputStyle) {
+        return writeInternal(() -> outputStyle.getWriter(objectMapper).writeValueAsString(value));
     }
 
     public JsonNode writeValueAsTree(Object object) {

--- a/factory/src/main/java/io/github/factoryfx/factory/storage/filesystem/FileSystemFactoryStorageHistory.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/storage/filesystem/FileSystemFactoryStorageHistory.java
@@ -3,6 +3,7 @@ package io.github.factoryfx.factory.storage.filesystem;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.factoryfx.factory.FactoryBase;
+import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 import io.github.factoryfx.factory.storage.DataStoragePatcher;
 import io.github.factoryfx.factory.storage.StoredDataMetadata;
@@ -82,7 +83,7 @@ public class FileSystemFactoryStorageHistory<R extends FactoryBase<?,R>> {
     public void updateHistory(R factoryRoot, StoredDataMetadata metadata) {
         String id=metadata.id;
 
-        writeFile(Paths.get(historyDirectory.toString()+"/"+id+".json"), migrationManager.write(factoryRoot));
+        writeFile(Paths.get(historyDirectory.toString()+"/"+id+".json"), migrationManager.write(factoryRoot, OutputStyle.COMPACT));
         writeFile(Paths.get(historyDirectory.toString()+"/"+id+"_metadata.json"), migrationManager.writeStorageMetadata(metadata));
         cache.put(id,metadata);
 

--- a/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
@@ -149,7 +149,7 @@ public class MigrationManager<R extends FactoryBase<?,R>> {
     }
 
     public String write(R root) {
-        return objectMapper.writeValueAsString(root);
+        return write(root, OutputStyle.DEFAULT);
     }
 
     public String write(R root, OutputStyle outputStyle) {

--- a/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
@@ -13,6 +13,7 @@ import com.google.common.base.Throwables;
 import io.github.factoryfx.factory.DataObjectIdResolver;
 import io.github.factoryfx.factory.FactoryBase;
 import io.github.factoryfx.factory.attribute.Attribute;
+import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 import io.github.factoryfx.factory.storage.RawFactoryDataAndMetadata;
 import io.github.factoryfx.factory.storage.ScheduledUpdateMetadata;
@@ -149,6 +150,10 @@ public class MigrationManager<R extends FactoryBase<?,R>> {
 
     public String write(R root) {
         return objectMapper.writeValueAsString(root);
+    }
+
+    public String write(R root, OutputStyle outputStyle) {
+        return objectMapper.writeValueAsString(root, outputStyle);
     }
 
     public String writeStorageMetadata(StoredDataMetadata metadata) {

--- a/factory/src/test/java/io/github/factoryfx/factory/jackson/SimpleObjectMapperTest.java
+++ b/factory/src/test/java/io/github/factoryfx/factory/jackson/SimpleObjectMapperTest.java
@@ -1,10 +1,10 @@
 package io.github.factoryfx.factory.jackson;
 
-import io.github.factoryfx.factory.attribute.types.StringListAttributeTest;
 import io.github.factoryfx.factory.testfactories.ExampleFactoryA;
 import io.github.factoryfx.factory.testfactories.ExampleFactoryB;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,6 +17,28 @@ class SimpleObjectMapperTest {
         exampleListFactory.referenceListAttribute.add(factoryB);
 
         ExampleFactoryA copy = ObjectMapperBuilder.build().copy(exampleListFactory);
-        Assertions.assertEquals(copy.referenceAttribute.get(),copy.referenceListAttribute.get(0));
+        assertEquals(copy.referenceAttribute.get(), copy.referenceListAttribute.get(0));
+    }
+
+    @Test
+    public void test_outputStyle() {
+        ExampleFactoryA factoryA = new ExampleFactoryA();
+        SimpleObjectMapper simpleObjectMapper = ObjectMapperBuilder.build();
+
+        String prettyStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.PRETTY);
+        String compactStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.COMPACT);
+        String defaultStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.DEFAULT);
+        Function<String, Boolean> isStringPretty = str -> str.contains("\" : ") && str.contains("\n") && !str.contains("\":") && str.contains("{\n");
+
+        System.out.println("prettyStr=" + prettyStr);
+        System.out.println("compactStr=" + compactStr);
+        System.out.println("defaultStr=" + defaultStr);
+
+        assertEquals(prettyStr, defaultStr);
+        assertTrue(isStringPretty.apply(prettyStr));
+        assertTrue(isStringPretty.apply(defaultStr));
+        assertTrue(compactStr.length() < prettyStr.length());
+        assertTrue(compactStr.length() < defaultStr.length());
+        assertFalse(isStringPretty.apply(compactStr));
     }
 }

--- a/factory/src/test/java/io/github/factoryfx/factory/jackson/SimpleObjectMapperTest.java
+++ b/factory/src/test/java/io/github/factoryfx/factory/jackson/SimpleObjectMapperTest.java
@@ -28,11 +28,8 @@ class SimpleObjectMapperTest {
         String prettyStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.PRETTY);
         String compactStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.COMPACT);
         String defaultStr = simpleObjectMapper.writeValueAsString(factoryA, OutputStyle.DEFAULT);
-        Function<String, Boolean> isStringPretty = str -> str.contains("\" : ") && str.contains("\n") && !str.contains("\":") && str.contains("{\n");
 
-        System.out.println("prettyStr=" + prettyStr);
-        System.out.println("compactStr=" + compactStr);
-        System.out.println("defaultStr=" + defaultStr);
+        Function<String, Boolean> isStringPretty = s -> s.contains("\" : ") && s.contains("\n") && !s.contains("\":") && s.contains("{\n");
 
         assertEquals(prettyStr, defaultStr);
         assertTrue(isStringPretty.apply(prettyStr));

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
@@ -2,10 +2,7 @@ package io.github.factoryfx.factory.datastorage.oracle;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.sql.Blob;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 
 public class JdbcUtil {
     public static void writeStringToBlob(String value, PreparedStatement preparedStatement, int index){
@@ -23,6 +20,24 @@ public class JdbcUtil {
             return new String(factoryBlob.getBytes(1L, (int) factoryBlob.length()), StandardCharsets.UTF_8);
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean isOracleWithCompressionSupport(Connection connection) {
+        try {
+            if (!connection.getMetaData().getDatabaseProductName().toLowerCase().contains("oracle")) {
+                return false;
+            }
+
+            String sql = "SELECT 1 FROM all_tab_columns WHERE table_name = 'USER_LOBS' AND column_name = 'COMPRESSION'";
+
+            try (Statement stmt = connection.createStatement();
+                 ResultSet rs = stmt.executeQuery(sql)) {
+                return rs.next();
+            }
+
+        } catch (SQLException e) {
+            return false;
         }
     }
 }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -31,17 +31,22 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
 
         try (Connection connection = connectionSupplier.get();
              Statement statement = connection.createStatement()) {
-            String sql = "CREATE TABLE FACTORY_CURRENT " +
-                    "(id VARCHAR(255) not NULL, " +
-                    " factory BLOB, " +
-                    " factoryMetadata BLOB, " +
-                    " PRIMARY KEY ( id ))";
 
-            statement.executeUpdate(sql);
+            DatabaseMetaData metaData = connection.getMetaData();
+
+            try (ResultSet rs = metaData.getTables(null, null, "FACTORY_CURRENT", new String[]{"TABLE"})) {
+                if (!rs.next()) {
+                    String sql = "CREATE TABLE FACTORY_CURRENT " +
+                            "(id VARCHAR(255) not NULL, " +
+                            " factory BLOB, " +
+                            " factoryMetadata BLOB, " +
+                            " PRIMARY KEY ( id ))";
+
+                    statement.executeUpdate(sql);
+                }
+            }
         } catch (SQLException e) {
-            //oracle don't know IF NOT EXISTS
-            //workaround ignore exception
-//            throw new RuntimeException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -51,7 +51,11 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
     }
 
     public OracledbDataStorage(Supplier<Connection> connectionSupplier, R initialDataParam, MigrationManager<R> migrationManager, SimpleObjectMapper objectMapper) {
-        this(connectionSupplier, initialDataParam, migrationManager, new OracledbDataStorageHistory<>(connectionSupplier, migrationManager),
+        this(connectionSupplier, initialDataParam, migrationManager, objectMapper, false);
+    }
+
+    public OracledbDataStorage(Supplier<Connection> connectionSupplier, R initialDataParam, MigrationManager<R> migrationManager, SimpleObjectMapper objectMapper, boolean withHistoryCompression) {
+        this(connectionSupplier, initialDataParam, migrationManager, new OracledbDataStorageHistory<>(connectionSupplier, migrationManager, withHistoryCompression),
                 new OracledbDataStorageFuture<>(connectionSupplier, migrationManager), objectMapper);
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -19,20 +19,25 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
         this.connectionSupplier = connectionSupplier;
         this.migrationManager = migrationManager;
 
-        try (Connection connection= connectionSupplier.get();
-             Statement statement = connection.createStatement()){
-                String sql = "CREATE TABLE FACTORY_FUTURE " +
-                        "(id VARCHAR(255) not NULL, " +
-                        " factory BLOB, " +
-                        " factoryMetadata BLOB, " +
-                        " PRIMARY KEY ( id ))";
+        try (Connection connection = connectionSupplier.get();
+             Statement statement = connection.createStatement()) {
 
-                statement.executeUpdate(sql);
+            DatabaseMetaData metaData = connection.getMetaData();
 
+            try (ResultSet rs = metaData.getTables(null, null, "FACTORY_FUTURE", new String[]{"TABLE"})) {
+                if (!rs.next()) {
+                    String sql = "CREATE TABLE FACTORY_FUTURE " +
+                            "(id VARCHAR(255) not NULL, " +
+                            " factory BLOB, " +
+                            " factoryMetadata BLOB, " +
+                            " PRIMARY KEY ( id ))";
+
+                    statement.executeUpdate(sql);
+
+                }
+            }
         } catch (SQLException e) {
-            //oracle don't know IF NOT EXISTS
-            //workaround ignore exception
-//            throw new RuntimeException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -18,12 +18,10 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?,R>> {
 
     private final MigrationManager<R> migrationManager;
     private final Supplier<Connection> connectionSupplier;
-    private final boolean withHistoryCompression;
 
     public OracledbDataStorageHistory(Supplier<Connection> connectionSupplier, MigrationManager<R> migrationManager, boolean withHistoryCompression) {
         this.connectionSupplier = connectionSupplier;
         this.migrationManager = migrationManager;
-        this.withHistoryCompression = withHistoryCompression;
 
         try (Connection connection = connectionSupplier.get();
              Statement statement = connection.createStatement()) {
@@ -98,7 +96,7 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?,R>> {
         try (Connection connection= connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_HISTORY(id,factory,factoryMetadata) VALUES (?,?,? )")) {
              preparedStatement.setString(1, id);
-             JdbcUtil.writeStringToBlob(migrationManager.write(factoryRoot, withHistoryCompression ? OutputStyle.COMPACT : OutputStyle.DEFAULT),preparedStatement,2);
+             JdbcUtil.writeStringToBlob(migrationManager.write(factoryRoot, OutputStyle.COMPACT),preparedStatement,2);
              JdbcUtil.writeStringToBlob(migrationManager.writeStorageMetadata(metadata),preparedStatement,3);
              preparedStatement.executeUpdate();
         } catch (SQLException e) {

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -22,20 +22,25 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?,R>> {
         this.connectionSupplier = connectionSupplier;
         this.migrationManager = migrationManager;
 
-        try (Connection connection= connectionSupplier.get();
-             Statement statement = connection.createStatement()){
-             String sql = "CREATE TABLE FACTORY_HISTORY " +
-                        "(id VARCHAR(255) not NULL, " +
-                        " factory BLOB, " +
-                        " factoryMetadata BLOB, " +
-                        " PRIMARY KEY ( id ))";
+        try (Connection connection = connectionSupplier.get();
+             Statement statement = connection.createStatement()) {
 
-             statement.executeUpdate(sql);
+            DatabaseMetaData metaData = connection.getMetaData();
 
+            try (ResultSet rs = metaData.getTables(null, null, "FACTORY_HISTORY", new String[]{"TABLE"})) {
+                if (!rs.next()) {
+                    String sql = "CREATE TABLE FACTORY_HISTORY " +
+                            "(id VARCHAR(255) not NULL, " +
+                            " factory BLOB, " +
+                            " factoryMetadata BLOB, " +
+                            " PRIMARY KEY ( id ))";
+
+                    statement.executeUpdate(sql);
+
+                }
+            }
         } catch (SQLException e) {
-            //oracle don't know "IF NOT EXISTS"
-            //workaround ignore exception
-//            throw new RuntimeException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/oracledbStorage/src/test/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistoryTest.java
+++ b/oracledbStorage/src/test/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistoryTest.java
@@ -16,14 +16,14 @@ public class OracledbDataStorageHistoryTest extends DatabaseTest {
 
     @Test
     public void test_empty() {
-        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         Assertions.assertTrue(oracledbDataStorageHistory.getHistoryFactoryList().isEmpty());
     }
 
     @Test
     public void test_add() {
-        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         StoredDataMetadata metadata = createDummyMetadata();
         oracledbDataStorageHistory.updateHistory(metadata,new ExampleFactoryA());
@@ -41,7 +41,7 @@ public class OracledbDataStorageHistoryTest extends DatabaseTest {
 
     @Test
     public void test_multi_add() {
-        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         {
             oracledbDataStorageHistory.updateHistory(createDummyMetadata(), new ExampleFactoryA());
@@ -60,23 +60,23 @@ public class OracledbDataStorageHistoryTest extends DatabaseTest {
 
     @Test
     public void test_restore() {
-        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         oracledbDataStorageHistory.updateHistory(createDummyMetadata(),new ExampleFactoryA());
         assertEquals(1, oracledbDataStorageHistory.getHistoryFactoryList().size());
 
-        OracledbDataStorageHistory<ExampleFactoryA> restored = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> restored = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
         assertEquals(1,restored.getHistoryFactoryList().size());
     }
 
     @Test
     public void test_getById() {
-        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> oracledbDataStorageHistory = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         oracledbDataStorageHistory.updateHistory(createDummyMetadata(),new ExampleFactoryA());
         assertEquals(1, oracledbDataStorageHistory.getHistoryFactoryList().size());
 
-        OracledbDataStorageHistory<ExampleFactoryA> history = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager());
+        OracledbDataStorageHistory<ExampleFactoryA> history = new OracledbDataStorageHistory<>(connectionSupplier, createMigrationManager(), false);
 
         ExampleFactoryA reloaded = oracledbDataStorageHistory.getHistoryFactory(new ArrayList<>(history.getHistoryFactoryList()).get(0).id);
         Assertions.assertNotNull(reloaded);


### PR DESCRIPTION
Factory history uses too much disk space, that's why we want to introduce an optional possibility to use compression. It does two things: oracle BLOB compression + jackson compact json printing