### PR TITLE
Oracle optimize data io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.1.2
 * **OracledbDataStorage**
     * optimize memory usage for storing and reading factory data
+    * make FACTORY_CURRENT update atomic
 
 # 4.1.1
 * **SimpleObjectMapper**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.2
+* **OracledbDataStorage**
+    * optimize memory usage for storing and reading factory data
+
 # 4.1.1
 * **SimpleObjectMapper**
     * cleanup

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ subprojects {
     }
 
     group = "io.github.factoryfx"
-    version = "4.1.1"
+    version = "4.1.2"
 
     publishing {
         publications {

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
@@ -163,8 +163,23 @@ public class SimpleObjectMapper {
         return writeInternal(() -> outputStyle.getWriter(objectMapper).writeValueAsString(value));
     }
 
+    public InputStream writeValueAsInputStream(JsonNode node) {
+        return writeValueAsInputStream(node, OutputStyle.DEFAULT);
+    }
+
+    public InputStream writeValueAsInputStream(JsonNode node, OutputStyle outputStyle) {
+        Object value = writeInternal(() -> objectMapper.treeToValue(node, Object.class));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeValue(out, value, outputStyle);
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+
+    public static void copy(InputStream in, OutputStream out) {
+        writeInternal(() -> in.transferTo(out));
+    }
+
     @SuppressWarnings("unchecked")
-    private <T> T readInternal(ResultFunction<T> function) {
+    private static <T> T readInternal(ResultFunction<T> function) {
         try {
             T value = function.apply();
             if (value instanceof FactoryBase<?, ?>) {
@@ -172,30 +187,32 @@ public class SimpleObjectMapper {
             }
             return value;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
-    private void writeInternal(VoidFunction function) {
+    private static void writeInternal(VoidFunction function) {
         try {
             function.apply();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
-    private <T> T writeInternal(ResultFunction<T> function) {
+    private static <T> T writeInternal(ResultFunction<T> function) {
         try {
             return function.apply();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
+    @FunctionalInterface
     private interface VoidFunction {
         void apply() throws IOException;
     }
 
+    @FunctionalInterface
     private interface ResultFunction<T> {
         T apply() throws IOException;
     }

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
@@ -163,19 +163,10 @@ public class SimpleObjectMapper {
         return writeInternal(() -> outputStyle.getWriter(objectMapper).writeValueAsString(value));
     }
 
-    public InputStream writeValueAsInputStream(JsonNode node) {
-        return writeValueAsInputStream(node, OutputStyle.DEFAULT);
-    }
-
-    public InputStream writeValueAsInputStream(JsonNode node, OutputStyle outputStyle) {
-        Object value = writeInternal(() -> objectMapper.treeToValue(node, Object.class));
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        writeValue(out, value, outputStyle);
-        return new ByteArrayInputStream(out.toByteArray());
-    }
-
-    public static void copy(InputStream in, OutputStream out) {
-        writeInternal(() -> in.transferTo(out));
+    public static void writeBytes(byte[] bytes, OutputStream out) {
+        writeInternal(() -> {
+            if (bytes != null) {out.write(bytes);}
+        });
     }
 
     @SuppressWarnings("unchecked")

--- a/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/jackson/SimpleObjectMapper.java
@@ -127,8 +127,12 @@ public class SimpleObjectMapper {
         writeInternal(() -> objectMapper.writeValue(gen, value));
     }
 
+    public void writeValue(OutputStream out, Object value, OutputStyle outputStyle) {
+        writeInternal(() -> outputStyle.getWriter(objectMapper).writeValue(out, value));
+    }
+
     public void writeValue(OutputStream out, Object value) {
-        writeInternal(() -> objectMapper.writeValue(out, value));
+        writeValue(out, value, OutputStyle.DEFAULT);
     }
 
     public void writeValue(Path path, Object value) {

--- a/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
+++ b/factory/src/main/java/io/github/factoryfx/factory/storage/migration/MigrationManager.java
@@ -72,7 +72,8 @@ public class MigrationManager<R extends FactoryBase<?,R>> {
         pathBasedRestorations.add(new PathDataRestore<>(path,setter,new AttributeValueListParser<>(new AttributeValueParser<>(objectMapper,clazz))));
     }
 
-    public R migrate(JsonNode rootNode, DataStorageMetadataDictionary dataStorageMetadataDictionary){
+    public R read(JsonNode rootNode, DataStorageMetadataDictionary dataStorageMetadataDictionary){
+
         DataJsonNode rootDataJson = new DataJsonNode((ObjectNode) rootNode);
         DataJsonNode previousRootDataJson = new DataJsonNode(rootNode.deepCopy());
         List<DataJsonNode> dataJsonNodes = rootDataJson.collectChildrenFromRoot();
@@ -147,17 +148,20 @@ public class MigrationManager<R extends FactoryBase<?,R>> {
         return root;
     }
 
-    public R read(JsonNode data, DataStorageMetadataDictionary dataStorageMetadataDictionary) {
-        return read(objectMapper.writeValueAsString(data),dataStorageMetadataDictionary);
+    public R read(String data, DataStorageMetadataDictionary dataStorageMetadataDictionary) {
+        return read(objectMapper.readTree(data), dataStorageMetadataDictionary);
     }
 
-    public R read(String data, DataStorageMetadataDictionary dataStorageMetadataDictionary) {
-        JsonNode migratedData = objectMapper.readTree(data);
-        return migrate(migratedData,dataStorageMetadataDictionary);
+    public StoredDataMetadata readStoredFactoryMetadata(JsonNode data) {
+        return objectMapper.readValue(data,StoredDataMetadata.class);
     }
 
     public StoredDataMetadata readStoredFactoryMetadata(String data) {
         return objectMapper.readValue(data,StoredDataMetadata.class);
+    }
+
+    public ScheduledUpdateMetadata readScheduledFactoryMetadata(JsonNode data) {
+        return objectMapper.readValue(data,ScheduledUpdateMetadata.class);
     }
 
     public ScheduledUpdateMetadata readScheduledFactoryMetadata(String data) {

--- a/factory/src/test/java/io/github/factoryfx/factory/storage/migration/datamigration/AttributeRenameTest.java
+++ b/factory/src/test/java/io/github/factoryfx/factory/storage/migration/datamigration/AttributeRenameTest.java
@@ -19,7 +19,7 @@ class AttributeRenameTest {
         dataMigrationManager.renameClass(ExampleDataAPrevious.class.getName(),ExampleDataA.class);
         dataMigrationManager.renameAttribute(ExampleDataA.class, "garbage", exampleDataA -> exampleDataA.stringAttribute);
 
-        ExampleDataA exampleDataA = dataMigrationManager.migrate(ObjectMapperBuilder.build().valueToTree(exampleDataAPrevious), exampleDataAPrevious.internal().createDataStorageMetadataDictionaryFromRoot());
+        ExampleDataA exampleDataA = dataMigrationManager.read(ObjectMapperBuilder.build().valueToTree(exampleDataAPrevious), exampleDataAPrevious.internal().createDataStorageMetadataDictionaryFromRoot());
         Assertions.assertEquals("123",exampleDataA.stringAttribute.get());
     }
 
@@ -33,7 +33,7 @@ class AttributeRenameTest {
         dataMigrationManager.renameAttribute(ExampleDataA.class, "garbage", exampleDataA -> exampleDataA.stringAttribute);
         dataMigrationManager.renameClass(ExampleDataAPrevious.class.getName(),ExampleDataA.class);
 
-        ExampleDataA exampleDataA = dataMigrationManager.migrate(ObjectMapperBuilder.build().valueToTree(exampleDataAPrevious), exampleDataAPrevious.internal().createDataStorageMetadataDictionaryFromRoot());
+        ExampleDataA exampleDataA = dataMigrationManager.read(ObjectMapperBuilder.build().valueToTree(exampleDataAPrevious), exampleDataAPrevious.internal().createDataStorageMetadataDictionaryFromRoot());
         Assertions.assertEquals("123",exampleDataA.stringAttribute.get());
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
@@ -8,21 +8,35 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.*;
+import java.util.List;
 
 public class JdbcUtil {
     public static void writeObjectToBlob(PreparedStatement preparedStatement,
                                          int index,
                                          SimpleObjectMapper objectMapper,
                                          Object value,
-                                         OutputStyle outputStyle) {
+                                         OutputStyle outputStyle,
+                                         List<Blob> allocatedBlobs) {
         try {
             Blob blob = preparedStatement.getConnection().createBlob();
+            allocatedBlobs.add(blob);
             try (OutputStream out = blob.setBinaryStream(1)) {
                 objectMapper.writeValue(out, value, outputStyle);
             }
             preparedStatement.setBlob(index, blob);
         } catch (SQLException | IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static void freeBlobs(List<Blob> blobs) {
+        for (Blob blob : blobs) {
+            if (blob != null) {
+                try {
+                    blob.free();
+                } catch (SQLException ignored) {
+                }
+            }
         }
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
@@ -1,7 +1,6 @@
 package io.github.factoryfx.factory.datastorage.oracle;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 
 import java.io.IOException;
@@ -9,19 +8,19 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.sql.*;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class JdbcUtil {
-    public static void writeObjectToBlob(PreparedStatement preparedStatement,
-                                         int index,
-                                         SimpleObjectMapper objectMapper,
-                                         Object value,
-                                         OutputStyle outputStyle,
-                                         List<Blob> allocatedBlobs) {
+
+    public static void writeToBlob(PreparedStatement preparedStatement,
+                                   int index,
+                                   Consumer<OutputStream> writer,
+                                   List<Blob> allocatedBlobs) {
         try {
             Blob blob = preparedStatement.getConnection().createBlob();
             allocatedBlobs.add(blob);
             try (OutputStream out = blob.setBinaryStream(1)) {
-                objectMapper.writeValue(out, value, outputStyle);
+                writer.accept(out);
             }
             preparedStatement.setBlob(index, blob);
         } catch (SQLException | IOException e) {

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
@@ -1,11 +1,12 @@
 package io.github.factoryfx.factory.datastorage.oracle;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.sql.*;
 
 public class JdbcUtil {
@@ -25,11 +26,10 @@ public class JdbcUtil {
         }
     }
 
-    public static String readStringFromBlob(ResultSet resultSet, String columnLabel) {
-        try {
-            Blob factoryBlob = resultSet.getBlob(columnLabel);
-            return new String(factoryBlob.getBytes(1L, (int) factoryBlob.length()), StandardCharsets.UTF_8);
-        } catch (SQLException e) {
+    public static JsonNode readTreeFromBlob(ResultSet resultSet, String columnLabel, SimpleObjectMapper objectMapper) {
+        try (InputStream blobStream = resultSet.getBinaryStream(columnLabel)) {
+            return objectMapper.readTree(blobStream);
+        } catch (SQLException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/JdbcUtil.java
@@ -1,15 +1,26 @@
 package io.github.factoryfx.factory.datastorage.oracle;
 
-import java.io.ByteArrayInputStream;
+import io.github.factoryfx.factory.jackson.OutputStyle;
+import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
 
 public class JdbcUtil {
-    public static void writeStringToBlob(String value, PreparedStatement preparedStatement, int index) {
+    public static void writeObjectToBlob(PreparedStatement preparedStatement,
+                                         int index,
+                                         SimpleObjectMapper objectMapper,
+                                         Object value,
+                                         OutputStyle outputStyle) {
         try {
-            final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-            preparedStatement.setBinaryStream(index, new ByteArrayInputStream(bytes), bytes.length);
-        } catch (SQLException e) {
+            Blob blob = preparedStatement.getConnection().createBlob();
+            try (OutputStream out = blob.setBinaryStream(1)) {
+                objectMapper.writeValue(out, value, outputStyle);
+            }
+            preparedStatement.setBlob(index, blob);
+        } catch (SQLException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -59,11 +59,11 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
 
     public OracledbDataStorage(Supplier<Connection> connectionSupplier, R initialDataParam, MigrationManager<R> migrationManager, SimpleObjectMapper objectMapper, boolean withHistoryCompression) {
         this(connectionSupplier,
-             initialDataParam,
-             migrationManager,
-             new OracledbDataStorageHistory<>(connectionSupplier, migrationManager, objectMapper, withHistoryCompression),
-             new OracledbDataStorageFuture<>(connectionSupplier, migrationManager, objectMapper),
-             objectMapper);
+                initialDataParam,
+                migrationManager,
+                new OracledbDataStorageHistory<>(connectionSupplier, migrationManager, objectMapper, withHistoryCompression),
+                new OracledbDataStorageFuture<>(connectionSupplier, migrationManager, objectMapper),
+                objectMapper);
     }
 
     @Override
@@ -156,40 +156,54 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         consumer.patch((ObjectNode) data, metadata, objectMapper);
         String metadataId = metadata.get("id").asText();
 
-        List<Blob> allocatedBlobs = new ArrayList<>();
-        try (Connection connection = connectionSupplier.get();
-             PreparedStatement truncate = connection.prepareStatement("TRUNCATE TABLE FACTORY_CURRENT");
-             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")
-        ) {
-            truncate.execute();
-            preparedStatement.setString(1, metadataId);
-            JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, data, OutputStyle.DEFAULT), allocatedBlobs);
-            JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
-            preparedStatement.executeUpdate();
+        try (Connection connection = connectionSupplier.get()) {
+            boolean initialAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            List<Blob> allocatedBlobs = new ArrayList<>();
+            try (PreparedStatement delete = connection.prepareStatement("DELETE FROM FACTORY_CURRENT");
+                 PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")) {
+                preparedStatement.setString(1, metadataId);
+                JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, data, OutputStyle.DEFAULT), allocatedBlobs);
+                JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
+                delete.execute();
+                preparedStatement.executeUpdate();
+                connection.commit();
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(initialAutoCommit);  //connection might be from a pool better restore state
+                JdbcUtil.freeBlobs(allocatedBlobs);
+            }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        } finally {
-            JdbcUtil.freeBlobs(allocatedBlobs);
         }
 
         oracledbDataStorageHistory.patchForId(consumer, metadataId);
     }
 
     private void update(R update, StoredDataMetadata metadata) {
-        List<Blob> allocatedBlobs = new ArrayList<>();
-        try (Connection connection = connectionSupplier.get();
-             PreparedStatement truncate = connection.prepareStatement("TRUNCATE TABLE FACTORY_CURRENT");
-             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")
-        ) {
-            truncate.execute();
-            preparedStatement.setString(1, metadata.id);
-            JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, update, OutputStyle.DEFAULT), allocatedBlobs);
-            JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
-            preparedStatement.executeUpdate();
+        try (Connection connection = connectionSupplier.get()) {
+            boolean initialAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            List<Blob> allocatedBlobs = new ArrayList<>();
+            try (PreparedStatement delete = connection.prepareStatement("DELETE FROM FACTORY_CURRENT");
+                 PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")) {
+                preparedStatement.setString(1, metadata.id);
+                JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, update, OutputStyle.DEFAULT), allocatedBlobs);
+                JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
+                delete.execute();
+                preparedStatement.executeUpdate();
+                connection.commit();
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(initialAutoCommit);  //connection might be from a pool better restore state
+                JdbcUtil.freeBlobs(allocatedBlobs);
+            }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        } finally {
-            JdbcUtil.freeBlobs(allocatedBlobs);
         }
         oracledbDataStorageHistory.updateHistory(metadata, update);
     }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -3,6 +3,7 @@ package io.github.factoryfx.factory.datastorage.oracle;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.factoryfx.factory.FactoryBase;
+import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 import io.github.factoryfx.factory.storage.*;
 import io.github.factoryfx.factory.storage.migration.MigrationManager;
@@ -161,8 +162,8 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadataId);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(data), preparedStatement, 2);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata), preparedStatement, 3);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, data, OutputStyle.DEFAULT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -178,8 +179,8 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadata.id);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(update), preparedStatement, 2);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata), preparedStatement, 3);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, update, OutputStyle.DEFAULT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -163,8 +163,8 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadataId);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, data, OutputStyle.DEFAULT, allocatedBlobs);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, data, OutputStyle.DEFAULT), allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -183,8 +183,8 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadata.id);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, update, OutputStyle.DEFAULT, allocatedBlobs);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, update, OutputStyle.DEFAULT), allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -159,7 +159,7 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         try (Connection connection = connectionSupplier.get()) {
             boolean initialAutoCommit = connection.getAutoCommit();
             connection.setAutoCommit(false);
-            List<Blob> allocatedBlobs = new ArrayList<>();
+            final List<Blob> allocatedBlobs = new ArrayList<>();
             try (PreparedStatement delete = connection.prepareStatement("DELETE FROM FACTORY_CURRENT");
                  PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")) {
                 preparedStatement.setString(1, metadataId);
@@ -186,7 +186,7 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         try (Connection connection = connectionSupplier.get()) {
             boolean initialAutoCommit = connection.getAutoCommit();
             connection.setAutoCommit(false);
-            List<Blob> allocatedBlobs = new ArrayList<>();
+            final List<Blob> allocatedBlobs = new ArrayList<>();
             try (PreparedStatement delete = connection.prepareStatement("DELETE FROM FACTORY_CURRENT");
                  PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")) {
                 preparedStatement.setString(1, metadata.id);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -9,7 +9,9 @@ import io.github.factoryfx.factory.storage.*;
 import io.github.factoryfx.factory.storage.migration.MigrationManager;
 
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -154,34 +156,40 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
         consumer.patch((ObjectNode) data, metadata, objectMapper);
         String metadataId = metadata.get("id").asText();
 
+        List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection = connectionSupplier.get();
              PreparedStatement truncate = connection.prepareStatement("TRUNCATE TABLE FACTORY_CURRENT");
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadataId);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, data, OutputStyle.DEFAULT);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, data, OutputStyle.DEFAULT, allocatedBlobs);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            JdbcUtil.freeBlobs(allocatedBlobs);
         }
 
         oracledbDataStorageHistory.patchForId(consumer, metadataId);
     }
 
     private void update(R update, StoredDataMetadata metadata) {
+        List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection = connectionSupplier.get();
              PreparedStatement truncate = connection.prepareStatement("TRUNCATE TABLE FACTORY_CURRENT");
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_CURRENT(id,factory,factoryMetadata) VALUES (?,?,? )")
         ) {
             truncate.execute();
             preparedStatement.setString(1, metadata.id);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, update, OutputStyle.DEFAULT);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, update, OutputStyle.DEFAULT, allocatedBlobs);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            JdbcUtil.freeBlobs(allocatedBlobs);
         }
         oracledbDataStorageHistory.updateHistory(metadata, update);
     }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorage.java
@@ -82,8 +82,8 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
 
             try (ResultSet resultSet = statement.executeQuery(sql)) {
                 if (resultSet.next()) {
-                    StoredDataMetadata factoryMetadata = migrationManager.readStoredFactoryMetadata(JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata"));
-                    return new DataAndId<>(migrationManager.read(JdbcUtil.readStringFromBlob(resultSet, "factory"), factoryMetadata.dataStorageMetadataDictionary), factoryMetadata.id);
+                    StoredDataMetadata factoryMetadata = migrationManager.readStoredFactoryMetadata(JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper));
+                    return new DataAndId<>(migrationManager.read(JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper), factoryMetadata.dataStorageMetadataDictionary), factoryMetadata.id);
                 }
             }
         } catch (SQLException e) {
@@ -134,26 +134,24 @@ public class OracledbDataStorage<R extends FactoryBase<?, R>> implements DataSto
 
     @Override
     public void patchCurrentData(DataStoragePatcher consumer) {
-        String dataString = null;
-        String metadataString = null;
+        JsonNode data;
+        JsonNode metadata;
         try (Connection connection = connectionSupplier.get();
              Statement statement = connection.createStatement()) {
             String sql = "SELECT * FROM FACTORY_CURRENT";
 
             try (ResultSet resultSet = statement.executeQuery(sql)) {
-                if (resultSet.next()) {
-                    dataString = JdbcUtil.readStringFromBlob(resultSet, "factory");
-                    metadataString = JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata");
+                if (!resultSet.next()) {
+                    throw new IllegalStateException("No data found");
                 }
+                data = JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper);
+                metadata = JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper);
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
 
-        JsonNode data = objectMapper.readTree(dataString);
-        JsonNode metadata = objectMapper.readTree(metadataString);
         consumer.patch((ObjectNode) data, metadata, objectMapper);
-
         String metadataId = metadata.get("id").asText();
 
         try (Connection connection = connectionSupplier.get();

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -83,7 +83,7 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
 
     public void addFuture(ScheduledUpdateMetadata metadata, R factoryRoot) {
         String id=metadata.id;
-        List<Blob> allocatedBlobs = new ArrayList<>();
+        final List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection= connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_FUTURE(id,factory,factoryMetadata) VALUES (?,?,? )")){
              preparedStatement.setString(1, id);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -87,8 +87,8 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
         try (Connection connection= connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_FUTURE(id,factory,factoryMetadata) VALUES (?,?,? )")){
              preparedStatement.setString(1, id);
-             JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.DEFAULT, allocatedBlobs);
-             JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
+             JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, factoryRoot, OutputStyle.DEFAULT), allocatedBlobs);
+             JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.DEFAULT), allocatedBlobs);
              preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -53,8 +53,8 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
 
             try (ResultSet resultSet =statement.executeQuery(sql)) {
                 if (resultSet.next()) {
-                    ScheduledUpdateMetadata metadata = migrationManager.readScheduledFactoryMetadata(JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata"));
-                    return migrationManager.read(JdbcUtil.readStringFromBlob(resultSet, "factory"),metadata.dataStorageMetadataDictionary);
+                    ScheduledUpdateMetadata metadata = migrationManager.readScheduledFactoryMetadata(JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper));
+                    return migrationManager.read(JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper),metadata.dataStorageMetadataDictionary);
                 }
             }
         } catch (SQLException e) {
@@ -72,7 +72,7 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
              ResultSet resultSet =statement.executeQuery("SELECT * FROM FACTORY_FUTURE")
             ){
             while (resultSet.next()) {
-                result.add(migrationManager.readScheduledFactoryMetadata(JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata")));
+                result.add(migrationManager.readScheduledFactoryMetadata(JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper)));
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -2,6 +2,7 @@ package io.github.factoryfx.factory.datastorage.oracle;
 
 
 import io.github.factoryfx.factory.FactoryBase;
+import io.github.factoryfx.factory.jackson.OutputStyle;
 import io.github.factoryfx.factory.jackson.SimpleObjectMapper;
 import io.github.factoryfx.factory.storage.ScheduledUpdateMetadata;
 import io.github.factoryfx.factory.storage.migration.MigrationManager;
@@ -85,8 +86,8 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
         try (Connection connection= connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_FUTURE(id,factory,factoryMetadata) VALUES (?,?,? )")){
              preparedStatement.setString(1, id);
-             JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(factoryRoot),preparedStatement,2);
-             JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata),preparedStatement,3);
+             JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.DEFAULT);
+             JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
              preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageFuture.java
@@ -10,6 +10,7 @@ import io.github.factoryfx.factory.storage.migration.MigrationManager;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
@@ -82,15 +83,17 @@ public class OracledbDataStorageFuture<R extends FactoryBase<?,R>> {
 
     public void addFuture(ScheduledUpdateMetadata metadata, R factoryRoot) {
         String id=metadata.id;
-
+        List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection= connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_FUTURE(id,factory,factoryMetadata) VALUES (?,?,? )")){
              preparedStatement.setString(1, id);
-             JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.DEFAULT);
-             JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT);
+             JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.DEFAULT, allocatedBlobs);
+             JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.DEFAULT, allocatedBlobs);
              preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            JdbcUtil.freeBlobs(allocatedBlobs);
         }
     }
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -142,7 +142,7 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
     public void updateHistory(StoredDataMetadata metadata, R factoryRoot) {
         String id = metadata.id;
-        List<Blob> allocatedBlobs = new ArrayList<>();
+        final List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection = connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_HISTORY(id,factory,factoryMetadata) VALUES (?,?,? )")) {
             preparedStatement.setString(1, id);
@@ -172,7 +172,7 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
-                        List<Blob> allocatedBlobs = new ArrayList<>();
+                        final List<Blob> allocatedBlobs = new ArrayList<>();
 
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
                             JdbcUtil.writeToBlob(updateStatement, 1, out -> objectMapper.writeValue(out, data, OutputStyle.COMPACT), allocatedBlobs);
@@ -214,7 +214,7 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
 
-                        List<Blob> allocatedBlobs = new ArrayList<>();
+                        final List<Blob> allocatedBlobs = new ArrayList<>();
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
                             JdbcUtil.writeToBlob(updateStatement, 1, out -> objectMapper.writeValue(out, data, OutputStyle.COMPACT), allocatedBlobs);
                             JdbcUtil.writeToBlob(updateStatement, 2, out -> objectMapper.writeValue(out, metadata, OutputStyle.COMPACT), allocatedBlobs);

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -145,8 +145,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
         try (Connection connection = connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_HISTORY(id,factory,factoryMetadata) VALUES (?,?,? )")) {
             preparedStatement.setString(1, id);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(factoryRoot, OutputStyle.COMPACT), preparedStatement, 2);
-            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata, OutputStyle.COMPACT), preparedStatement, 3);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.COMPACT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.COMPACT);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -173,8 +173,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                         String metadataId = metadata.get("id").asText();
 
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(data, OutputStyle.COMPACT), updateStatement, 1);
-                            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata, OutputStyle.COMPACT), updateStatement, 2);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {
@@ -210,8 +210,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                         String metadataId = metadata.get("id").asText();
 
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(data, OutputStyle.COMPACT), updateStatement, 1);
-                            JdbcUtil.writeStringToBlob(objectMapper.writeValueAsString(metadata, OutputStyle.COMPACT), updateStatement, 2);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -187,6 +187,9 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                     }
                 }
                 connection.commit();
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
             } finally {
                 connection.setAutoCommit(initialAutoCommit);  //connection might be from a pool better restore state
             }
@@ -225,6 +228,9 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                     }
                 }
                 connection.commit();
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
             } finally {
                 connection.setAutoCommit(initialAutoCommit);  //connection might be from a pool better restore state
             }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -12,6 +12,7 @@ import io.github.factoryfx.factory.storage.migration.MigrationManager;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Supplier;
 
 public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
@@ -141,15 +142,17 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
     public void updateHistory(StoredDataMetadata metadata, R factoryRoot) {
         String id = metadata.id;
-
+        List<Blob> allocatedBlobs = new ArrayList<>();
         try (Connection connection = connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_HISTORY(id,factory,factoryMetadata) VALUES (?,?,? )")) {
             preparedStatement.setString(1, id);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.COMPACT);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.COMPACT);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.COMPACT, allocatedBlobs);
+            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
+        } finally {
+            JdbcUtil.freeBlobs(allocatedBlobs);
         }
     }
 
@@ -169,14 +172,17 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
+                        List<Blob> allocatedBlobs = new ArrayList<>();
 
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT);
-                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT, allocatedBlobs);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {
                             throw new RuntimeException(e1);
+                        } finally {
+                            JdbcUtil.freeBlobs(allocatedBlobs);
                         }
                     }
                 }
@@ -205,13 +211,16 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
 
+                        List<Blob> allocatedBlobs = new ArrayList<>();
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT);
-                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT, allocatedBlobs);
+                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {
                             throw new RuntimeException(e1);
+                        } finally {
+                            JdbcUtil.freeBlobs(allocatedBlobs);
                         }
                     }
                 }

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -113,8 +113,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
             statement.setString(1, id);
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (resultSet.next()) {
-                    StoredDataMetadata metadata = migrationManager.readStoredFactoryMetadata(JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata"));
-                    return migrationManager.read(JdbcUtil.readStringFromBlob(resultSet, "factory"), metadata.dataStorageMetadataDictionary);
+                    StoredDataMetadata metadata = migrationManager.readStoredFactoryMetadata(JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper));
+                    return migrationManager.read(JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper), metadata.dataStorageMetadataDictionary);
                 }
             }
         } catch (SQLException e) {
@@ -131,7 +131,7 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
              Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery("SELECT * FROM FACTORY_HISTORY")) {
             while (resultSet.next()) {
-                result.add(migrationManager.readStoredFactoryMetadata(JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata")));
+                result.add(migrationManager.readStoredFactoryMetadata(JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper)));
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -164,11 +164,9 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
                 try (ResultSet resultSet = statement.executeQuery(sql)) {
                     while (resultSet.next()) {
-                        String dataString = JdbcUtil.readStringFromBlob(resultSet, "factory");
-                        String metadataString = JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata");
+                        JsonNode data = JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper);
+                        JsonNode metadata = JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper);
 
-                        JsonNode data = objectMapper.readTree(dataString);
-                        JsonNode metadata = objectMapper.readTree(metadataString);
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
 
@@ -201,11 +199,9 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
                 try (ResultSet resultSet = statement.executeQuery()) {
                     while (resultSet.next()) {
-                        String dataString = JdbcUtil.readStringFromBlob(resultSet, "factory");
-                        String metadataString = JdbcUtil.readStringFromBlob(resultSet, "factoryMetadata");
+                        JsonNode data = JdbcUtil.readTreeFromBlob(resultSet, "factory", objectMapper);
+                        JsonNode metadata = JdbcUtil.readTreeFromBlob(resultSet, "factoryMetadata", objectMapper);
 
-                        JsonNode data = objectMapper.readTree(dataString);
-                        JsonNode metadata = objectMapper.readTree(metadataString);
                         consumer.patch((ObjectNode) data, metadata, objectMapper);
                         String metadataId = metadata.get("id").asText();
 

--- a/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
+++ b/oracledbStorage/src/main/java/io/github/factoryfx/factory/datastorage/oracle/OracledbDataStorageHistory.java
@@ -146,8 +146,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
         try (Connection connection = connectionSupplier.get();
              PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO FACTORY_HISTORY(id,factory,factoryMetadata) VALUES (?,?,? )")) {
             preparedStatement.setString(1, id);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 2, objectMapper, factoryRoot, OutputStyle.COMPACT, allocatedBlobs);
-            JdbcUtil.writeObjectToBlob(preparedStatement, 3, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 2, out -> objectMapper.writeValue(out, factoryRoot, OutputStyle.COMPACT), allocatedBlobs);
+            JdbcUtil.writeToBlob(preparedStatement, 3, out -> objectMapper.writeValue(out, metadata, OutputStyle.COMPACT), allocatedBlobs);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -175,8 +175,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
                         List<Blob> allocatedBlobs = new ArrayList<>();
 
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT, allocatedBlobs);
-                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
+                            JdbcUtil.writeToBlob(updateStatement, 1, out -> objectMapper.writeValue(out, data, OutputStyle.COMPACT), allocatedBlobs);
+                            JdbcUtil.writeToBlob(updateStatement, 2, out -> objectMapper.writeValue(out, metadata, OutputStyle.COMPACT), allocatedBlobs);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {
@@ -213,8 +213,8 @@ public class OracledbDataStorageHistory<R extends FactoryBase<?, R>> {
 
                         List<Blob> allocatedBlobs = new ArrayList<>();
                         try (PreparedStatement updateStatement = connection.prepareStatement("UPDATE FACTORY_HISTORY SET factory=?,factoryMetadata=? WHERE id=?")) {
-                            JdbcUtil.writeObjectToBlob(updateStatement, 1, objectMapper, data, OutputStyle.COMPACT, allocatedBlobs);
-                            JdbcUtil.writeObjectToBlob(updateStatement, 2, objectMapper, metadata, OutputStyle.COMPACT, allocatedBlobs);
+                            JdbcUtil.writeToBlob(updateStatement, 1, out -> objectMapper.writeValue(out, data, OutputStyle.COMPACT), allocatedBlobs);
+                            JdbcUtil.writeToBlob(updateStatement, 2, out -> objectMapper.writeValue(out, metadata, OutputStyle.COMPACT), allocatedBlobs);
                             updateStatement.setString(3, metadataId);
                             updateStatement.executeUpdate();
                         } catch (SQLException e1) {


### PR DESCRIPTION
Use streams instead of large String and byte[] objects for storing and reading factory data in Oracle DB

Before:
storing: Object -> String -> byte[] -> BLOB
reading: BLOB -> byte[] -> String -> JsonNode -> Object

Now:
storing: Object -> OutputStream -> Blob -> BLOB
reading: BLOB -> InputStream -> JsonNode -> Object


CONTEXT:
OOM error with a large configuration